### PR TITLE
Sending remote throttle value to VESC

### DIFF
--- a/demo-remote-esc.lisp
+++ b/demo-remote-esc.lisp
@@ -1,0 +1,12 @@
+(defun setRemote (msg) {
+(set-remote-state (bufget-f32 msg 0 'little-endian) (bufget-f32 msg 4 'little-endian) (bufget-u8 msg 8) (bufget-u8 msg 9) (bufget-u8 msg 10))
+;(print (get-remote-state))
+})
+
+(loopwhile-thd 100 t {
+        (def msg (canmsg-recv 0 -1))
+        (def msgLen (- (buflen msg) 2))
+        (def crc (crc16 msg msgLen))
+        (if (eq crc (bufget-u16 msg msgLen)) (setRemote msg))
+        ;(sleep 2);sleep two seconds
+})

--- a/demo-remote-express.lisp
+++ b/demo-remote-express.lisp
@@ -1,0 +1,33 @@
+(def can 39)
+(def esp-now-remote-mac '(132 252 230 80 168 12))
+
+(esp-now-start)
+(wifi-set-chan 1)
+;84:FC:E6:50:A8:0C
+(esp-now-add-peer esp-now-remote-mac) ; Add broadcast address as peer
+
+;(print (list "starting" (get-mac-addr) (wifi-get-chan)))
+
+(defun proc-data (src des data rssi) {
+    ;(print (list "Received" src des data rssi))
+    ;(print (list "Received" data))
+    (def dataLen (buflen data))
+    (def crc (crc16 data dataLen))
+    (define data2 (array-create (+ dataLen 2)))
+    (bufcpy data2 0 data 0 dataLen)
+    (bufset-u16 data2 dataLen crc)
+    (canmsg-send can 0 data2)
+    (esp-now-send '(132 252 230 80 168 12) data)
+    ;(print "Responded")
+    }
+)
+
+(defun event-handler ()
+    (loopwhile t
+        (recv
+            ((event-esp-now-rx (? src) (? des) (? data) (? rssi)) (proc-data src des data rssi))
+            (_ nil)
+)))
+
+(event-register-handler (spawn event-handler))
+(event-enable 'event-esp-now-rx)

--- a/src/remote/remoteinputs.c
+++ b/src/remote/remoteinputs.c
@@ -15,49 +15,62 @@ static const char *TAG = "PUBMOTE-REMOTEINPUTS";
 #define BUTTON_PIN GPIO_NUM_0
 
 uint8_t THROTTLE_VALUE = 128;
+RemoteDataUnion remote_data;
 
 void throttle_task(void *pvParameters) {
   // TODO - IMPLEMENT ADC CONTINUOUS READING
 
-  ESP_LOGI(TAG, "Throttle task ended");
-  // terminate self
-  vTaskDelete(NULL);
-}
+  while (1) {
+    // read potentiometer and apply to THROTTLE_VALUE
+    //  adc1_config_width(ADC_WIDTH_BIT_DEFAULT); // ADC_WIDTH_BIT_12
+    //  adc1_config_channel_atten(ADC1_CHANNEL_0, ADC_ATTEN_DB_0);
+    //  int val = adc1_get_raw(ADC1_CHANNEL_0);
+    // remote_data.data.js_y = (float)val;
+    remote_data.data.js_y = 0.69f;
+    // THROTTLE_VALUE = val / 16;
+    // ESP_LOGI(REMOTEINPUTS_TAG, "Throttle position: %d\n", THROTTLE_VALUE);
+    //  vTaskDelay(THROTTLE_LOOP_TIME / portTICK_PERIOD_MS);
+    //}
 
-void init_throttle() {
-  xTaskCreate(throttle_task, "throttle_task", 4096, NULL, 2, NULL);
-}
-
-static void button_single_click_cb(void *arg, void *usr_data) {
-  ESP_LOGI(TAG, "BUTTON SINGLE CLICK");
-}
-
-static void button_double_click_cb(void *arg, void *usr_data) {
-  ESP_LOGI(TAG, "BUTTON DOUBLE CLICK");
-}
-
-static void button_long_press_cb(void *arg, void *usr_data) {
-  ESP_LOGI(TAG, "BUTTON LONG PRESSS");
-}
-
-void init_buttons() {
-  // create gpio button
-  button_config_t gpio_btn_cfg = {
-      .type = BUTTON_TYPE_GPIO,
-      .long_press_time = CONFIG_BUTTON_LONG_PRESS_TIME_MS,
-      .short_press_time = CONFIG_BUTTON_SHORT_PRESS_TIME_MS,
-      .gpio_button_config =
-          {
-              .gpio_num = BUTTON_PIN,
-              .active_level = 0,
-          },
-  };
-  button_handle_t gpio_btn = iot_button_create(&gpio_btn_cfg);
-  if (NULL == gpio_btn) {
-    ESP_LOGE(TAG, "Button create failed");
+    ESP_LOGI(REMOTEINPUTS_TAG, "Throttle task ended");
+    // terminate self
+    vTaskDelete(NULL);
   }
 
-  iot_button_register_cb(gpio_btn, BUTTON_SINGLE_CLICK, button_single_click_cb, NULL);
-  iot_button_register_cb(gpio_btn, BUTTON_DOUBLE_CLICK, button_double_click_cb, NULL);
-  iot_button_register_cb(gpio_btn, BUTTON_LONG_PRESS_UP, button_long_press_cb, NULL);
-}
+  void init_throttle() {
+    xTaskCreate(throttle_task, "throttle_task", 4096, NULL, 2, NULL);
+  }
+
+  static void button_single_click_cb(void *arg, void *usr_data) {
+    ESP_LOGI(TAG, "BUTTON SINGLE CLICK");
+  }
+
+  static void button_double_click_cb(void *arg, void *usr_data) {
+    ESP_LOGI(TAG, "BUTTON DOUBLE CLICK");
+  }
+
+  static void button_long_press_cb(void *arg, void *usr_data) {
+    ESP_LOGI(TAG, "BUTTON LONG PRESSS");
+  }
+
+  void init_buttons() {
+    // create gpio button
+    button_config_t gpio_btn_cfg = {
+        .type = BUTTON_TYPE_GPIO,
+        .long_press_time = CONFIG_BUTTON_LONG_PRESS_TIME_MS,
+        .short_press_time = CONFIG_BUTTON_SHORT_PRESS_TIME_MS,
+        .gpio_button_config =
+            {
+                .gpio_num = BUTTON_PIN,
+                .active_level = 0,
+            },
+    };
+    button_handle_t gpio_btn = iot_button_create(&gpio_btn_cfg);
+    if (NULL == gpio_btn) {
+      ESP_LOGE(TAG, "Button create failed");
+    }
+
+    iot_button_register_cb(gpio_btn, BUTTON_SINGLE_CLICK, button_single_click_cb, NULL);
+    iot_button_register_cb(gpio_btn, BUTTON_DOUBLE_CLICK, button_double_click_cb, NULL);
+    iot_button_register_cb(gpio_btn, BUTTON_LONG_PRESS_UP, button_long_press_cb, NULL);
+  }

--- a/src/remote/remoteinputs.c
+++ b/src/remote/remoteinputs.c
@@ -19,58 +19,46 @@ RemoteDataUnion remote_data;
 
 void throttle_task(void *pvParameters) {
   // TODO - IMPLEMENT ADC CONTINUOUS READING
+  remote_data.data.js_y = 0.69f;
+  ESP_LOGI(TAG, "Throttle task ended");
+  // terminate self
+  vTaskDelete(NULL);
+}
 
-  while (1) {
-    // read potentiometer and apply to THROTTLE_VALUE
-    //  adc1_config_width(ADC_WIDTH_BIT_DEFAULT); // ADC_WIDTH_BIT_12
-    //  adc1_config_channel_atten(ADC1_CHANNEL_0, ADC_ATTEN_DB_0);
-    //  int val = adc1_get_raw(ADC1_CHANNEL_0);
-    // remote_data.data.js_y = (float)val;
-    remote_data.data.js_y = 0.69f;
-    // THROTTLE_VALUE = val / 16;
-    // ESP_LOGI(REMOTEINPUTS_TAG, "Throttle position: %d\n", THROTTLE_VALUE);
-    //  vTaskDelay(THROTTLE_LOOP_TIME / portTICK_PERIOD_MS);
-    //}
+void init_throttle() {
+  xTaskCreate(throttle_task, "throttle_task", 4096, NULL, 2, NULL);
+}
 
-    ESP_LOGI(REMOTEINPUTS_TAG, "Throttle task ended");
-    // terminate self
-    vTaskDelete(NULL);
+static void button_single_click_cb(void *arg, void *usr_data) {
+  ESP_LOGI(TAG, "BUTTON SINGLE CLICK");
+}
+
+static void button_double_click_cb(void *arg, void *usr_data) {
+  ESP_LOGI(TAG, "BUTTON DOUBLE CLICK");
+}
+
+static void button_long_press_cb(void *arg, void *usr_data) {
+  ESP_LOGI(TAG, "BUTTON LONG PRESSS");
+}
+
+void init_buttons() {
+  // create gpio button
+  button_config_t gpio_btn_cfg = {
+      .type = BUTTON_TYPE_GPIO,
+      .long_press_time = CONFIG_BUTTON_LONG_PRESS_TIME_MS,
+      .short_press_time = CONFIG_BUTTON_SHORT_PRESS_TIME_MS,
+      .gpio_button_config =
+          {
+              .gpio_num = BUTTON_PIN,
+              .active_level = 0,
+          },
+  };
+  button_handle_t gpio_btn = iot_button_create(&gpio_btn_cfg);
+  if (NULL == gpio_btn) {
+    ESP_LOGE(TAG, "Button create failed");
   }
 
-  void init_throttle() {
-    xTaskCreate(throttle_task, "throttle_task", 4096, NULL, 2, NULL);
-  }
-
-  static void button_single_click_cb(void *arg, void *usr_data) {
-    ESP_LOGI(TAG, "BUTTON SINGLE CLICK");
-  }
-
-  static void button_double_click_cb(void *arg, void *usr_data) {
-    ESP_LOGI(TAG, "BUTTON DOUBLE CLICK");
-  }
-
-  static void button_long_press_cb(void *arg, void *usr_data) {
-    ESP_LOGI(TAG, "BUTTON LONG PRESSS");
-  }
-
-  void init_buttons() {
-    // create gpio button
-    button_config_t gpio_btn_cfg = {
-        .type = BUTTON_TYPE_GPIO,
-        .long_press_time = CONFIG_BUTTON_LONG_PRESS_TIME_MS,
-        .short_press_time = CONFIG_BUTTON_SHORT_PRESS_TIME_MS,
-        .gpio_button_config =
-            {
-                .gpio_num = BUTTON_PIN,
-                .active_level = 0,
-            },
-    };
-    button_handle_t gpio_btn = iot_button_create(&gpio_btn_cfg);
-    if (NULL == gpio_btn) {
-      ESP_LOGE(TAG, "Button create failed");
-    }
-
-    iot_button_register_cb(gpio_btn, BUTTON_SINGLE_CLICK, button_single_click_cb, NULL);
-    iot_button_register_cb(gpio_btn, BUTTON_DOUBLE_CLICK, button_double_click_cb, NULL);
-    iot_button_register_cb(gpio_btn, BUTTON_LONG_PRESS_UP, button_long_press_cb, NULL);
-  }
+  iot_button_register_cb(gpio_btn, BUTTON_SINGLE_CLICK, button_single_click_cb, NULL);
+  iot_button_register_cb(gpio_btn, BUTTON_DOUBLE_CLICK, button_double_click_cb, NULL);
+  iot_button_register_cb(gpio_btn, BUTTON_LONG_PRESS_UP, button_long_press_cb, NULL);
+}

--- a/src/remote/remoteinputs.h
+++ b/src/remote/remoteinputs.h
@@ -8,4 +8,33 @@
 void init_throttle();
 void init_buttons();
 
+typedef struct {
+  float js_y;
+  float js_x;
+  char bt_c;
+  char bt_z;
+  char is_rev;
+} remote_data_t;
+
+typedef union {
+  remote_data_t data;
+  uint8_t bytes[sizeof(remote_data_t)];
+} RemoteDataUnion;
+
+typedef enum {
+  BUTTON_NONE,
+  BUTTON_CLICK,
+  BUTTON_DOUBLE_CLICK,
+  BUTTON_LONG_PRESS,
+} ButtonState;
+
+extern u_int8_t THROTTLE_VALUE;
+extern ButtonState BUTTON_STATE;
+extern TaskHandle_t buttonTaskHandle;
+extern RemoteDataUnion remote_data;
+
+void throttle_task(void *pvParameters);
+void button_task(void *pvParameters);
+void register_button_isr();
+
 #endif

--- a/src/remote/remoteinputs.h
+++ b/src/remote/remoteinputs.h
@@ -21,20 +21,6 @@ typedef union {
   uint8_t bytes[sizeof(remote_data_t)];
 } RemoteDataUnion;
 
-typedef enum {
-  BUTTON_NONE,
-  BUTTON_CLICK,
-  BUTTON_DOUBLE_CLICK,
-  BUTTON_LONG_PRESS,
-} ButtonState;
-
-extern u_int8_t THROTTLE_VALUE;
-extern ButtonState BUTTON_STATE;
-extern TaskHandle_t buttonTaskHandle;
 extern RemoteDataUnion remote_data;
-
-void throttle_task(void *pvParameters);
-void button_task(void *pvParameters);
-void register_button_isr();
 
 #endif

--- a/src/remote/transmitter.c
+++ b/src/remote/transmitter.c
@@ -5,6 +5,7 @@
 #include "esp_system.h"
 #include "esp_wifi.h"
 #include "peers.h"
+#include "remoteinputs.h"
 #include "time.h"
 #include <stdbool.h>
 #include <stdio.h>
@@ -31,7 +32,7 @@ static void transmitter_task(void *pvParameters) {
       continue;
     }
 
-    esp_err_t result = esp_now_send(&PEER_MAC_ADDRESS, (uint8_t *)&my_data, sizeof(my_data));
+    esp_err_t result = esp_now_send(&PEER_MAC_ADDRESS, (uint8_t *)&remote_data.bytes, sizeof(remote_data.bytes));
 
     if (result != ESP_OK) {
       // Handle error if needed

--- a/src/remote/transmitter.h
+++ b/src/remote/transmitter.h
@@ -1,5 +1,6 @@
 #ifndef __TRANSMITTER_H
 #define __TRANSMITTER_H
+#include <stdint.h>
 #include <stdio.h>
 
 #include "esp_now.h"


### PR DESCRIPTION
Data struct and framework for using the vesc remote protocol. Lisp scripts for vesc express to recieve over esp-now, calculate crc16, send to can to ESC, have ESC read can message, check crc16 and then have ESC set throttle. If adc code is added on the remote side to control the value (currently hardcoded at 0.69f), we'll have a working remote.