### PR TITLE
Add automated release drafts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Publish Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+# References: 
+# https://github.com/release-drafter/release-drafter
+# https://docs.platformio.org/en/stable/integration/ci/github-actions.html
+jobs:
+  build_and_release:
+    if: github.repository == 'contactsimonwilson/PubRemote'
+    
+    permissions:
+      # Write permission is required to create a github release
+      contents: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+          
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Build PlatformIO Project
+        run: pio run
+
+      - name: Attach ZIPs
+        uses: softprops/action-gh-release@v2
+        with: 
+          files: "*.zip"
+          fail_on_unmatched_files: true
+          generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ autosave/
 managed_components/
 .DS_Store
 sdkconfig.*.old
+
+# Compiled release zips
+*.zip

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Publish Release](https://github.com/contactsimonwilson/PubRemote/actions/workflows/release.yml/badge.svg?branch=master)](https://github.com/contactsimonwilson/PubRemote/actions/workflows/release.yml)
+
 # Pubmote AKA Pubremote
 
 Welcome to Pubmote!

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,13 +10,15 @@
 
 [platformio]
 src_dir = firmware/src
-default_envs = waveshare_esp32s3_touch_128
+default_envs = avaspark_esp32s3_touch_128, cowmote_esp32s3_tdisplay_143
 
 [common]
 debug_tool = esp-builtin
 build_type = debug ; debug, test, release
 debug_speed = 12000
-extra_scripts = pre:prebuild_hook.py
+extra_scripts =
+  pre:prebuild_hook.py
+  post:postbuild_hook.py
 platform = espressif32@6.9.0
 framework = espidf
 monitor_speed = 115200

--- a/postbuild_hook.py
+++ b/postbuild_hook.py
@@ -1,0 +1,37 @@
+Import("env")
+import os
+import zipfile
+
+def post_program_action(source, target, env):
+    # Define relevant paths
+    project_dir = os.getcwd()
+    build_dir = os.path.join(project_dir, ".pio" + os.sep + "build")
+
+    # Define list of files to zip
+    files_to_zip = [
+        "firmware.bin",
+        "partitions.bin",
+        "bootloader.bin"
+    ]
+
+    # Build debugging
+    print("Creating ZIP for release of " + env["PIOENV"])
+    
+    # Create zip in the root of the directory
+    ZipFile = zipfile.ZipFile(project_dir + os.sep + env["PIOENV"] + ".zip", "w" )
+        
+    #  Zip relevant files
+    for file in files_to_zip: 
+        ZipFile.write(os.path.join(build_dir, env["PIOENV"], file), arcname=os.path.basename(file), compress_type=zipfile.ZIP_DEFLATED)
+
+    # Close stream
+    ZipFile.close()
+
+# Build if github is in the environment
+# TODO | Trigger on local environment flag as well
+if "GITHUB_ACTION" in os.environ:
+    # Will only run if the build was not cached
+    env.AddPostAction("buildprog", post_program_action)
+
+    # # Alternative that will always run
+    # env.AddPostAction("checkprogsize", post_program_action)


### PR DESCRIPTION
Any semver-formatted (vX.X.X) tag on the master branch will trigger an automated build and release action.
- Automatically create build ZIP files from build definitions
- Attach build ZIP files to new release drafts
- Automatically create release draft on version tags