### PR TITLE
Nightly builds should kick off at 11:30

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -2,7 +2,7 @@ name: Nightly Builds
 
 on:
   schedule:
-    - cron: "59 23 * * *"
+    - cron: "30 23 * * *"
 
 concurrency:
   group: ${{ github.workflow }}


### PR DESCRIPTION
Should fix the build taking too long and running into the next day
