### PR TITLE
Update GH actions with comments, code, and cleanup

### DIFF
--- a/.github/workflows/firmware-tool.yml
+++ b/.github/workflows/firmware-tool.yml
@@ -1,12 +1,17 @@
 name: Deploy to GitHub Pages
 
+# Run on every push to master under the firmware tool path
 on:
   push:
     branches:
-      - master  # Set your default branch here
+      - master
+    paths:
+      - firmware_tool/**
 
 jobs:
   build-and-deploy:
+    if: github.repository == 'contactsimonwilson/PubRemote'
+
     runs-on: ubuntu-latest
     
     steps:
@@ -16,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'  # Specify your Node.js version
+          node-version: '20'
           
       - name: Install dependencies
         working-directory: ./firmware_tool  # Change to the firmware_tool directory

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,5 +1,6 @@
 name: Nightly Builds
 
+# Run every night at 11:30 PM
 on:
   schedule:
     - cron: "30 23 * * *" 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,6 @@
-# See https://docs.platformio.org/en/stable/integration/ci/github-actions.html
 name: PlatformIO CI
 
+# Run on every opened, reopened, or updated PR
 on:
   pull_request:
     types: 
@@ -10,6 +10,8 @@ on:
     branches:
       - master
 
+# References: 
+# https://docs.platformio.org/en/stable/integration/ci/github-actions.html
 jobs:
   build:
     if: github.repository == 'contactsimonwilson/PubRemote'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: Publish Release
 
+# Run on every semantic version tag
 on:
   push:
     tags:


### PR DESCRIPTION
firmware-tool:
- Firmware tool should only deploy to GH pages if the related path has been changed in the push to the master branch
- Node version 20 can be used, no reason for using the older v18

Others:
- Added comments with description of the run conditions
