### PR TITLE
Fix dark text toggle crash

### DIFF
--- a/firmware/src/remote/remoteinputs.h
+++ b/firmware/src/remote/remoteinputs.h
@@ -49,7 +49,7 @@
 void init_thumbstick();
 void init_buttons();
 void reset_button_state();
-void enable_power_button(bool enable); // TODO - disable while active
+void enable_power_button(bool enable);
 
 float convert_adc_to_axis(int adc_value, int min_val, int mid_val, int max_val, int deadband, float expo, bool invert);
 

--- a/firmware/src/remote/remoteinputs.h
+++ b/firmware/src/remote/remoteinputs.h
@@ -49,7 +49,7 @@
 void init_thumbstick();
 void init_buttons();
 void reset_button_state();
-void enable_power_button(bool enable);
+void enable_power_button(bool enable); // TODO - disable while active
 
 float convert_adc_to_axis(int adc_value, int min_val, int mid_val, int max_val, int deadband, float expo, bool invert);
 

--- a/firmware/src/utilities/screen_utils.c
+++ b/firmware/src/utilities/screen_utils.c
@@ -250,6 +250,8 @@ void apply_ui_scale(lv_obj_t *element) {
 
 void reload_screens() {
   if (LVGL_lock(-1)) {
+    lv_obj_clean(ui_MenuScreen);
+    lv_obj_clean(ui_StatsScreen);
     ui_MenuScreen_screen_init();
     ui_StatsScreen_screen_init();
     apply_ui_scale(ui_StatsScreen);


### PR DESCRIPTION
Fix dark text toggle crash by correctly disposing of permanent screens before loading them again
Closes #108 