### PR TITLE
Add waveshare_esp32s3_touch_amoled_143 to default build list

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 
 [platformio]
 src_dir = firmware/src
-default_envs = avaspark_esp32s3_touch_128, cowmote_esp32s3_tdisplay_143
+default_envs = avaspark_esp32s3_touch_128, cowmote_esp32s3_tdisplay_143, waveshare_esp32s3_touch_amoled_143
 
 [common]
 debug_tool = esp-builtin


### PR DESCRIPTION
Since we're moving toward this display more and more, this should be included in the automated release builds.