### PR TITLE
Fix firmware tool hang with fresh esp32 device

### DIFF
--- a/firmware_tool/src/services/espService.ts
+++ b/firmware_tool/src/services/espService.ts
@@ -222,7 +222,7 @@ export class ESPService {
     const startTime = Date.now();
 
     while (Date.now() - startTime < timeout) {
-      const data = await this.espLoader?.transport.rawRead();
+      const data = await this.espLoader?.transport.rawRead(timeout);
       if (data) {
         response += data;
         if (response.includes("\n")) {


### PR DESCRIPTION
Fix firmware tool hang with fresh esp32 device by forwarding the timeout command through to the underlying function, allowing the timeout loop to exit correctly.