### PR TITLE
Add I2C mutex to ensure thread-safe access across all devices

### DIFF
--- a/firmware/src/charge/sy6970/charge_driver_sy6970.cpp
+++ b/firmware/src/charge/sy6970/charge_driver_sy6970.cpp
@@ -13,7 +13,6 @@ static const char *TAG = "PUBREMOTE-CHARGE_DRIVER_SY6970";
 
 // SY6970 I2C address (0x6A is the typical address)
 #define SY6970_ADDR                 0x6A
-#define SY6970_I2C_NUM             I2C_NUM_0
 
 // SY6970 instance
 static PowersSY6970 sy6970;

--- a/firmware/src/charge/sy6970/charge_driver_sy6970.cpp
+++ b/firmware/src/charge/sy6970/charge_driver_sy6970.cpp
@@ -20,18 +20,18 @@ static PowersSY6970 sy6970;
 
 static int sy6970_read_reg(uint8_t device_addr, uint8_t reg_addr, uint8_t *data, uint8_t len)
 {
-    return (int)i2c_read_with_mutex(device_addr, reg_addr, data, len, 500) ;
+    return (int)i2c_read_with_mutex(device_addr, reg_addr, data, len, 500);
 }
 
 static int sy6970_write_reg(uint8_t device_addr, uint8_t reg_addr, uint8_t *data, uint8_t len)
 {
-    return (int)i2c_write_with_mutex(device_addr, reg_addr, data, len, 500) ;
+    return (int)i2c_write_with_mutex(device_addr, reg_addr, data, len, 500);
 }
 
 /**
  * @brief Initialize the SY6970 power management chip
  */
-static esp_err_t sy6970_init(void)
+static esp_err_t sy6970_init()
 {
     #if defined(PMU_SDA) && defined(PMU_SCL)
 
@@ -54,7 +54,7 @@ static esp_err_t sy6970_init(void)
 /**
  * @brief Set power parameters for SY6970
  */
-static esp_err_t set_power_parameters(void)
+static esp_err_t set_power_parameters()
 {
     esp_err_t ret = ESP_OK;
     

--- a/firmware/src/charge/sy6970/charge_driver_sy6970.cpp
+++ b/firmware/src/charge/sy6970/charge_driver_sy6970.cpp
@@ -7,6 +7,7 @@
 #include "XPowersLib.h"
 #include <charge/charge_driver.h>
 #include "config.h"
+#include "remote/i2c.h"
 
 static const char *TAG = "PUBREMOTE-CHARGE_DRIVER_SY6970";
 
@@ -17,6 +18,16 @@ static const char *TAG = "PUBREMOTE-CHARGE_DRIVER_SY6970";
 // SY6970 instance
 static PowersSY6970 sy6970;
 
+static int sy6970_read_reg(uint8_t device_addr, uint8_t reg_addr, uint8_t *data, uint8_t len)
+{
+    return (int)i2c_read_with_mutex(device_addr, reg_addr, data, len, 500) ;
+}
+
+static int sy6970_write_reg(uint8_t device_addr, uint8_t reg_addr, uint8_t *data, uint8_t len)
+{
+    return (int)i2c_write_with_mutex(device_addr, reg_addr, data, len, 500) ;
+}
+
 /**
  * @brief Initialize the SY6970 power management chip
  */
@@ -25,7 +36,7 @@ static esp_err_t sy6970_init(void)
     #if defined(PMU_SDA) && defined(PMU_SCL)
 
     // Initialize the SY6970 with the XPowersLib
-    bool result = sy6970.begin(SY6970_I2C_NUM, SY6970_ADDR, PMU_SDA, PMU_SCL);
+    bool result = sy6970.begin(SY6970_ADDR, sy6970_read_reg, sy6970_write_reg);
     if (!result) {
         ESP_LOGE(TAG, "Failed to initialize SY6970");
         return ESP_FAIL;

--- a/firmware/src/remote/i2c.c
+++ b/firmware/src/remote/i2c.c
@@ -3,13 +3,160 @@
 #include "driver/i2c.h"
 #include "esp_err.h"
 #include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
 
 static const char *TAG = "PUBREMOTE-I2C";
 
-// TODO -I2C mutex for thread safety
-// static SemaphoreHandle_t i2c_mutex = NULL;
+static SemaphoreHandle_t i2c_mutex = NULL;
+
+#define I2C_MASTER_NUM I2C_NUM_0
+
+// I2C write function with mutex protection
+esp_err_t i2c_write_with_mutex(uint8_t device_addr, uint8_t reg_addr, uint8_t *data, size_t len, int timeout_ms) {
+  if (i2c_mutex == NULL) {
+    ESP_LOGE(TAG, "I2C mutex not initialized");
+    return ESP_FAIL;
+  }
+
+  // Take mutex with timeout
+  if (xSemaphoreTake(i2c_mutex, pdMS_TO_TICKS(timeout_ms)) != pdTRUE) {
+    ESP_LOGE(TAG, "Failed to take I2C mutex for write");
+    return ESP_ERR_TIMEOUT;
+  }
+
+  esp_err_t ret = ESP_OK;
+  i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+
+  // Start condition
+  i2c_master_start(cmd);
+
+  // Write device address + write bit
+  i2c_master_write_byte(cmd, (device_addr << 1) | I2C_MASTER_WRITE, true);
+
+  // Write register address
+  i2c_master_write_byte(cmd, reg_addr, true);
+
+  // Write data
+  if (len > 0 && data != NULL) {
+    i2c_master_write(cmd, data, len, true);
+  }
+
+  // Stop condition
+  i2c_master_stop(cmd);
+
+  // Execute the command
+  ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, pdMS_TO_TICKS(timeout_ms));
+
+  // Clean up
+  i2c_cmd_link_delete(cmd);
+
+  // Release mutex
+  xSemaphoreGive(i2c_mutex);
+
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "I2C write failed: %s", esp_err_to_name(ret));
+  }
+
+  return ret;
+}
+
+// I2C read function with mutex protection
+esp_err_t i2c_read_with_mutex(uint8_t device_addr, uint8_t reg_addr, uint8_t *data, size_t len, int timeout_ms) {
+  if (i2c_mutex == NULL) {
+    ESP_LOGE(TAG, "I2C mutex not initialized");
+    return ESP_FAIL;
+  }
+
+  if (data == NULL || len == 0) {
+    ESP_LOGE(TAG, "Invalid read parameters");
+    return ESP_ERR_INVALID_ARG;
+  }
+
+  // Take mutex with timeout
+  if (xSemaphoreTake(i2c_mutex, pdMS_TO_TICKS(timeout_ms)) != pdTRUE) {
+    ESP_LOGE(TAG, "Failed to take I2C mutex for read");
+    return ESP_ERR_TIMEOUT;
+  }
+
+  esp_err_t ret = ESP_OK;
+  i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+
+  // Start condition
+  i2c_master_start(cmd);
+
+  // Write device address + write bit to set register address
+  i2c_master_write_byte(cmd, (device_addr << 1) | I2C_MASTER_WRITE, true);
+
+  // Write register address
+  i2c_master_write_byte(cmd, reg_addr, true);
+
+  // Repeated start condition
+  i2c_master_start(cmd);
+
+  // Write device address + read bit
+  i2c_master_write_byte(cmd, (device_addr << 1) | I2C_MASTER_READ, true);
+
+  // Read data
+  if (len > 1) {
+    i2c_master_read(cmd, data, len - 1, I2C_MASTER_ACK);
+  }
+  i2c_master_read_byte(cmd, &data[len - 1], I2C_MASTER_NACK);
+
+  // Stop condition
+  i2c_master_stop(cmd);
+
+  // Execute the command
+  ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, pdMS_TO_TICKS(timeout_ms));
+
+  // Clean up
+  i2c_cmd_link_delete(cmd);
+
+  // Release mutex
+  xSemaphoreGive(i2c_mutex);
+
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "I2C read failed: %s", esp_err_to_name(ret));
+  }
+
+  return ret;
+}
+
+// i2c_mutex_lock
+bool i2c_lock(int timeout_ms) {
+  if (i2c_mutex == NULL) {
+    ESP_LOGE(TAG, "I2C not initialized");
+    return false;
+  }
+
+  if (xSemaphoreTake(i2c_mutex, pdMS_TO_TICKS(timeout_ms)) == pdTRUE) {
+    return true;
+  }
+  else {
+    ESP_LOGE(TAG, "Failed to acquire I2C mutex");
+    return false;
+  }
+}
+
+bool i2c_unlock() {
+  if (i2c_mutex == NULL) {
+    ESP_LOGE(TAG, "I2C not initialized");
+    return false;
+  }
+
+  if (xSemaphoreGive(i2c_mutex) == pdTRUE) {
+    return true;
+  }
+  else {
+    ESP_LOGE(TAG, "Failed to release I2C mutex");
+    return false;
+  }
+}
 
 void init_i2c() {
+  // Create a mutex for I2C operations
+  i2c_mutex = xSemaphoreCreateMutex();
+
   /* Initilize I2C */
   const i2c_config_t i2c_conf = {.mode = I2C_MODE_MASTER,
                                  .sda_io_num = I2C_SDA,
@@ -20,6 +167,6 @@ void init_i2c() {
 
   ESP_LOGI(TAG, "Initializing I2C for display touch");
   /* Initialize I2C */
-  ESP_ERROR_CHECK(i2c_param_config(I2C_NUM_0, &i2c_conf));
-  ESP_ERROR_CHECK(i2c_driver_install(I2C_NUM_0, i2c_conf.mode, 0, 0, 0));
+  ESP_ERROR_CHECK(i2c_param_config(I2C_MASTER_NUM, &i2c_conf));
+  ESP_ERROR_CHECK(i2c_driver_install(I2C_MASTER_NUM, i2c_conf.mode, 0, 0, 0));
 }

--- a/firmware/src/remote/i2c.h
+++ b/firmware/src/remote/i2c.h
@@ -1,9 +1,24 @@
 #ifndef __I2C_H
 #define __I2C_H
 
+#include "esp_err.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
+#include "stdio.h"
 
-void init_i2c();
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+  esp_err_t i2c_write_with_mutex(uint8_t device_addr, uint8_t reg_addr, uint8_t *data, size_t len, int timeout_ms);
+  esp_err_t i2c_read_with_mutex(uint8_t device_addr, uint8_t reg_addr, uint8_t *data, size_t len, int timeout_ms);
+  bool i2c_lock(int timeout_ms);
+  bool i2c_unlock();
+  void init_i2c();
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/prebuild_hook.py
+++ b/prebuild_hook.py
@@ -4,7 +4,7 @@ import hashlib
 
 major_version = 0
 minor_version = 2
-patch_version = 11
+patch_version = 12
 
 def generate_build_id():
     # Get current timestamp


### PR DESCRIPTION
Add I2C mutex to ensure thread-safe access across all devices
Will prevent i2c read/write failures when adding PMU/IMU/DRV interfaces