### PR TITLE
Fix calibration screen by accessing config

### DIFF
--- a/firmware/src/screens/calibration_screen.c
+++ b/firmware/src/screens/calibration_screen.c
@@ -1,3 +1,4 @@
+#include "config.h"
 #include "driver/gpio.h"
 #include "esp_log.h"
 #include "remote/screen.h"


### PR DESCRIPTION
Include config so that calibration screen gets feature detection correctly