### PR TITLE
Revert connection_task ulStackDepth adjustment causing crash

### DIFF
--- a/firmware/src/remote/connection.c
+++ b/firmware/src/remote/connection.c
@@ -126,5 +126,5 @@ void connection_init() {
     connection_connect_to_default_peer();
   }
 
-  xTaskCreatePinnedToCore(connection_task, "connection_task", 1024, NULL, 20, NULL, 0);
+  xTaskCreatePinnedToCore(connection_task, "connection_task", 4096, NULL, 20, NULL, 0);
 }

--- a/prebuild_hook.py
+++ b/prebuild_hook.py
@@ -4,7 +4,7 @@ import hashlib
 
 major_version = 0
 minor_version = 5
-patch_version = 1
+patch_version = 2
 
 def generate_build_id():
     # Get current timestamp


### PR DESCRIPTION
This fixes a crash loop when connected to a VESC Express.